### PR TITLE
Fix duplicate execution of test cases in different namespaces

### DIFF
--- a/src/TestNameExtractor.php
+++ b/src/TestNameExtractor.php
@@ -13,12 +13,12 @@ final class TestNameExtractor
     {
         $testNames = [];
         foreach (explode(\PHP_EOL, $input) as $line) {
-            $lastSlashPosition = strrpos($line, '\\');
-            if (false === $lastSlashPosition) {
+            $listPosition = strpos($line, '- ');
+            if (false === $listPosition) {
                 continue;
             }
 
-            $testCase = substr($line, $lastSlashPosition + 1);
+            $testCase = substr($line, $listPosition + 2);
 
             $firstColonPosition = strrpos($testCase, '::');
             if (false === $firstColonPosition) {

--- a/tests/TestNameExtractorTest.php
+++ b/tests/TestNameExtractorTest.php
@@ -34,22 +34,22 @@ EOL;
             [
                 self::MANY_TESTS,
                 [
-                    'PhpmdJsonResultsParserTest',
-                    'PhpstanJsonResultsParserTest',
-                    'PsalmJsonResultsParserTest',
-                    'SarbJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\PhpmdJsonResultsParser\PhpmdJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\PhpstanJsonResultsParser\PhpstanJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\PsalmJsonResultsParser\PsalmJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParserTest',
                 ],
             ],
             [
                 " - DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParserTest::testConversion",
                 [
-                    'SarbJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParserTest',
                 ],
             ],
             [
                 self::DUPLICATE_TEST,
                 [
-                    'SarbJsonResultsParserTest',
+                    'DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParserTest',
                 ],
             ],
         ];

--- a/tsplit
+++ b/tsplit
@@ -40,6 +40,11 @@ $testNameExtractor = new TestNameExtractor();
 
 $testClassSplitter = new TestClassSplitter($testNameExtractor->getDeDupedTestClassNames($stdIn));
 
-$output = join('|', $testClassSplitter->getTestCaseNames($cliArgumentParser->getNumerator(), $cliArgumentParser->getDenominator()));
+$testCaseNames = $testClassSplitter->getTestCaseNames($cliArgumentParser->getNumerator(), $cliArgumentParser->getDenominator());
+$escapedTestCaseNames = array_map(function (string $testCaseName): string {
+    return str_replace('\\', '\\\\', $testCaseName);
+}, $testCaseNames);
+
+$output = join('|', $escapedTestCaseNames);
 
 echo $output;


### PR DESCRIPTION
We are seeing the same test being executed in different batches. I believe this is due to the splitter not working on fully qualified class names.

I am currently testing if this solves our issue, planning to come back with feedback soon.